### PR TITLE
Fix parse errors

### DIFF
--- a/cids.ttl
+++ b/cids.ttl
@@ -1258,8 +1258,7 @@ cids:Activity rdf:type owl:Class ;
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty org:hasIdentifier ;
-                                owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                owl:onDataRange xsd:string
+                                owl:allValuesFrom xsd:string
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty org:hasName ;
@@ -2168,8 +2167,7 @@ cids:IndicatorReport rdf:type owl:Class ;
                                      ] ,
                                      [ rdf:type owl:Restriction ;
                                        owl:onProperty cids:hasComment ;
-                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                       owl:onDataRange xsd:string
+                                       owl:allValuesFrom xsd:string
                                      ] ,
                                      [ rdf:type owl:Restriction ;
                                        owl:onProperty org:hasName ;

--- a/cids.ttl
+++ b/cids.ttl
@@ -30,23 +30,23 @@
 @base <https://ontology.commonapproach.org/cids> .
 
 <https://ontology.commonapproach.org/cids> rdf:type owl:Ontology ;
-                                            owl:versionIRI <https://ontology.commonapproach.org/cids/3.1.0> ;
+                                            owl:versionIRI <https://ontology.commonapproach.org/cids/3.2.0> ;
                                             owl:imports <http://ontology.eil.utoronto.ca/ISO21972/iso21972.owl> ,
                                                         <http://ontology.eil.utoronto.ca/tove/activity.owl> ,
                                                         <http://ontology.eil.utoronto.ca/tove/icontact.owl> ,
                                                         <http://ontology.eil.utoronto.ca/tove/organization.owl> ,
                                                         <http://www.w3.org/2006/time.rdf> ,
                                                         <https://codelist.commonapproach.org/codeLists/SDGImpacts>;
-                                            cc:license "Common Impact Data Standard V3.1.0 © 2025 by Common Approach to Impact Measurement is licensed under CC BY-SA 4.0. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/" ;
+                                            cc:license "Common Impact Data Standard V3.2.0 © 2025 by Common Approach to Impact Measurement is licensed under CC BY-SA 4.0. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/" ;
                                             dcterms:creator cids:ac ;
                                             dcterms:date "06-16-2025" ;
                                             dcterms:description "The Common Impact Data Standard (CIDS) provides a standard representation for the core concepts and attributes that underlie impact models (e.g., logic model, impact thesis, theory of change, etc.), inputs, activities, outputs, and outcomes."@en ;
                                             dcterms:title "Common Impact Data Standard"@en ;
                                             vann:preferredNamespacePrefix "cids" ;
                                             vann:preferredNamespaceUri "https://ontology.commonapproach.org/cids#" ;
-                                            owl:priorVersion <https://ontology.commonapproach.org/cids/3.0> ;
-                                            owl:versionInfo "3.1.0"@en ;
-                                            adms:relatedDocumentation "Common Approach to Impact Measurement (2023) “Technical Guide: The Common Impact Data Standard V3.1.0 An Ontology for Representing Impact”, Common Approach to Impact Measurement. DOI 10.5281/zenodo.7930431 https://www.commonapproach.org/wp-content/uploads/2023/05/Common-Approach_Common-Impact-Data-Standard_Current-version.pdf"@en .
+                                            owl:priorVersion <https://ontology.commonapproach.org/cids/3.1.0> ;
+                                            owl:versionInfo "3.2.0"@en ;
+                                            adms:relatedDocumentation "Common Approach to Impact Measurement (2023) “Technical Guide: The Common Impact Data Standard V3.2.0 An Ontology for Representing Impact”, Common Approach to Impact Measurement. DOI 10.5281/zenodo.7930431 https://www.commonapproach.org/wp-content/uploads/2023/05/Common-Approach_Common-Impact-Data-Standard_Current-version.pdf"@en .
 
 #################################################################
 #    Annotation properties

--- a/cids.ttl
+++ b/cids.ttl
@@ -1258,6 +1258,7 @@ cids:Activity rdf:type owl:Class ;
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty org:hasIdentifier ;
+                                owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onDataRange xsd:string
                               ] ,
                               [ rdf:type owl:Restriction ;
@@ -1702,7 +1703,7 @@ cids:ImpactModel rdf:type owl:Class ;
                  rdfs:subClassOf cids:cidsThing ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty cids:forOrganization ;
-                                   # owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass cids:Organization
                                  ] ,
                                  [ rdf:type owl:Restriction ;
@@ -1826,7 +1827,7 @@ cids:ImpactReport rdf:type owl:Class ;
                                   ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty cids:hasComment ;
-                                    # owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
@@ -2167,6 +2168,7 @@ cids:IndicatorReport rdf:type owl:Class ;
                                      ] ,
                                      [ rdf:type owl:Restriction ;
                                        owl:onProperty cids:hasComment ;
+                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                        owl:onDataRange xsd:string
                                      ] ,
                                      [ rdf:type owl:Restriction ;
@@ -3044,7 +3046,7 @@ cids:Target rdf:type owl:Class ;
                             ] ,
                             [ rdf:type owl:Restriction ;
                               owl:onProperty cids:hasComment ;
-                              # owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:string
                             ] ;
             rdfs:comment """<p>The target is used to report the target value of an indicator and/or indicator report for some time interval. In addition to the target value and time interval of the target, this class also reports the units of measure of the target, the date the target was created, the name of the target, and any comment about the target that the user may wish to add.</p>


### PR DESCRIPTION
This branch fixes some syntax errors that were causing Widoco and Protege to parse `cids.ttl` badly, resulting in Error classes. I'm not certain that the `qualifiedCardinality` clauses I've added are *logically* correct, but they seem to be required in order for the `onDataRange` restriction to be parsed correctly.

I've also added a commit to fix the version metadata in the ontology to match the 3.2.0 release we're preparing.