### PR TITLE
Corrected forFunder from objectproperty to datatypeproperty

### DIFF
--- a/contexts/sffContext.jsonld
+++ b/contexts/sffContext.jsonld
@@ -113,10 +113,6 @@
     "primaryPopulationServed": {
       "@id": "sff:primaryPopulationServed",
       "@type": "@id"
-    },
-    "forFunderId": {
-      "@id": "sff:forFunderId",
-      "@type": "@id"
     }
   }
 }

--- a/sff.ttl
+++ b/sff.ttl
@@ -245,12 +245,11 @@ sff:forEDG
   cids:belongsToTier cids:SFFTier .
 
 sff:forFunder
-  a owl:ObjectProperty ;
+  a owl:DatatypeProperty ;
   rdfs:domain sff:FundingStatus ;
-  rdfs:range cids:Organization ;
   rdfs:label "for Funder"@en ;
   cids:hasName "for Funder" ;
-  rdfs:comment "Links a funding status to the funder or investor that is being reported on."@en ;
+  rdfs:comment "States the name of the fund, funder or investor that is linked from the forOrganization property of FundingStatus."@en ;
   void:inDataset sff:datasetdefinition ;
   rdfs:isDefinedBy sff: ;
   cids:belongsToTier cids:SFFTier .

--- a/validation/shacl/sff.shacl.ttl
+++ b/validation/shacl/sff.shacl.ttl
@@ -484,9 +484,9 @@ csh:SFFProperty_hasBoardProfile_PropertyShape
 
 csh:SFFProperty_forFunder_PropertyShape
         rdf:type        sh:PropertyShape;
-        sh:class        cids:Organization;
+        sh:datatype     xsd:string;
         sh:name         "forFunder";
-        sh:nodeKind     sh:BlankNodeOrIRI;
+        sh:nodeKind     sh:Literal;
         sh:path         sff:forFunder;
         csh:activeTier  cids:SFFTier .
 
@@ -2038,9 +2038,9 @@ sff:hasBoardProfile  rdf:type  owl:ObjectProperty;
         rdfs:label    "hasBoardProfile"@en;
         csh:memberOf  owl:ObjectProperty .
 
-sff:forFunder  rdf:type  owl:ObjectProperty;
+sff:forFunder  rdf:type  owl:DatatypeProperty;
         rdfs:label    "for Funder"@en;
-        csh:memberOf  owl:ObjectProperty .
+        csh:memberOf  owl:DatatypeProperty .
 
 sff:forEDG  rdf:type  owl:ObjectProperty;
         rdfs:label    "forEDG"@en;


### PR DESCRIPTION
Daniel S. pointed out an accidental contradiction in type for the forFunder property of FundingState. Now corrected. 